### PR TITLE
CR-2189: [Not CAR] [AWS] Ensure ElastiCache Redis clusters have automatic backup turned on

### DIFF
--- a/cloudrail/knowledge/context/aws/elasticache/elasticache_cluster.py
+++ b/cloudrail/knowledge/context/aws/elasticache/elasticache_cluster.py
@@ -17,6 +17,8 @@ class ElastiCacheCluster(NetworkEntity):
             subnet_ids: The IDs of the subnet in the subnet group.
             is_in_default_vpc: True if the ElasticCache cluster is in the
                 default VPC.
+            snapshot_retention_limit: Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them.
+            engine: Name of the cache engine to be used for the ElasticCache cluster
     """
     def __init__(self,
                  region: str,
@@ -25,6 +27,8 @@ class ElastiCacheCluster(NetworkEntity):
                  arn: str,
                  replication_group_id: Optional[str],
                  security_group_ids: Optional[list],
+                 snapshot_retention_limit: Optional[int],
+                 engine: str,
                  subnet_group_name: Optional[str] = 'default'):
         super().__init__(cluster_name, account, region, AwsServiceName.AWS_ELASTICACHE_CLUSTER)
         self.replication_group_id: str = replication_group_id
@@ -34,6 +38,8 @@ class ElastiCacheCluster(NetworkEntity):
         self.subnet_group_name: Optional[str] = subnet_group_name
         self.subnet_ids: Optional[List[str]] = None
         self.is_in_default_vpc: bool = self.subnet_group_name == 'default'
+        self.snapshot_retention_limit: Optional[int] = snapshot_retention_limit
+        self.engine: str = engine
 
     def get_keys(self) -> List[str]:
         return [self.get_arn()]

--- a/cloudrail/knowledge/rules/aws/aws_rules_metadata.yaml
+++ b/cloudrail/knowledge/rules/aws/aws_rules_metadata.yaml
@@ -3459,3 +3459,22 @@ rules_metadata:
   security_layer: iam
   resource_type:
   - iam
+
+- rule_id: non_car_elasticache_redis_cluster_automatic_backup_turned_on
+  cloud_provider: amazon_web_services
+  name: Ensure ElastiCache Redis clusters have automatic backup turned on
+  severity: medium
+  description:
+    Cloudrail will review the ElastiCache Redis clusters configuration in your environment.
+    If a Redis cluster has automatic backup turned off, Cloudrail will highlight it as a violation.
+  human_readable_logic:
+    Cloudrail will review the ElastiCache Redis clusters within your AWS account and
+    Terraform plan to check if if they have automatic backup turned on.
+  remediation_steps_console:
+    Follow the guide at <https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-automatic.html>
+    in order to enable automatic backups for a ElastiCache Redis cluster.
+  remediation_steps_tf: For the aws_elasticache_cluster resource, set the snapshot_retention_limit argument to a value higher than 0.
+  rule_type: non_context_aware
+  security_layer: disaster_recovery
+  resource_type:
+  - database

--- a/cloudrail/knowledge/rules/aws/non_context_aware/ensure_elasticache_redis_cluster_auto_backup_enabled_rule.py
+++ b/cloudrail/knowledge/rules/aws/non_context_aware/ensure_elasticache_redis_cluster_auto_backup_enabled_rule.py
@@ -1,0 +1,25 @@
+from typing import List, Dict
+from cloudrail.knowledge.context.environment_context import EnvironmentContext
+from cloudrail.knowledge.rules.aws.aws_base_rule import AwsBaseRule
+from cloudrail.knowledge.rules.base_rule import Issue
+from cloudrail.knowledge.rules.rule_parameters.base_paramerter import ParameterType
+
+
+class EnsureElasticacheRedisClusterAutoBackupEnabledRule(AwsBaseRule):
+
+    def get_id(self) -> str:
+        return 'non_car_elasticache_redis_cluster_automatic_backup_turned_on'
+
+    def execute(self, env_context: EnvironmentContext, parameters: Dict[ParameterType, any]) -> List[Issue]:
+        issues: List[Issue] = []
+
+        for elasticache_cluster in env_context.elasticache_clusters:
+            if elasticache_cluster.engine == 'redis' and elasticache_cluster.snapshot_retention_limit == 0:
+                issues.append(
+                    Issue(
+                        f'The {elasticache_cluster.get_type()} `{elasticache_cluster.get_friendly_name()}` has automatic backups turned off',
+                        elasticache_cluster, elasticache_cluster))
+            return issues
+
+    def should_run_rule(self, environment_context: EnvironmentContext) -> bool:
+        return bool(environment_context.elasticache_clusters)

--- a/cloudrail/version.py
+++ b/cloudrail/version.py
@@ -1,1 +1,1 @@
-__version__ = 'v0.0.20'
+__version__ = 'v0.0.21-beta.5'

--- a/tests/knowledge/rules/aws/non_context_aware/test_ensure_elasticache_redis_cluster_auto_backup_enabled_rule.py
+++ b/tests/knowledge/rules/aws/non_context_aware/test_ensure_elasticache_redis_cluster_auto_backup_enabled_rule.py
@@ -1,0 +1,49 @@
+import unittest
+
+from cloudrail.dev_tools.rule_test_utils import create_empty_entity
+from cloudrail.knowledge.context.aws.elasticache.elasticache_cluster import ElastiCacheCluster
+from cloudrail.knowledge.context.environment_context import EnvironmentContext
+from cloudrail.knowledge.rules.aws.non_context_aware.ensure_elasticache_redis_cluster_auto_backup_enabled_rule import \
+    EnsureElasticacheRedisClusterAutoBackupEnabledRule
+from cloudrail.knowledge.rules.base_rule import RuleResultType
+
+
+class TestEnsureElasticacheRedisClusterAutoBackupEnabledRule(unittest.TestCase):
+    def setUp(self):
+        self.rule = EnsureElasticacheRedisClusterAutoBackupEnabledRule()
+
+    def test_non_car_elasticache_redis_cluster_automatic_backup_turned_on_fail(self):
+        # Arrange
+        elasticache_cluster: ElastiCacheCluster = create_empty_entity(ElastiCacheCluster)
+        elasticache_cluster.engine = 'redis'
+        elasticache_cluster.snapshot_retention_limit = 0
+        context = EnvironmentContext(elasticache_clusters=[elasticache_cluster])
+        # Act
+        result = self.rule.run(context, {})
+        # Assert
+        self.assertEqual(RuleResultType.FAILED, result.status)
+        self.assertEqual(1, len(result.issues))
+
+    def test_non_car_elasticache_redis_cluster_automatic_backup_turned_on_pass(self):
+        # Arrange
+        elasticache_cluster: ElastiCacheCluster = create_empty_entity(ElastiCacheCluster)
+        elasticache_cluster.engine = 'redis'
+        elasticache_cluster.snapshot_retention_limit = 5
+        context = EnvironmentContext(elasticache_clusters=[elasticache_cluster])
+        # Act
+        result = self.rule.run(context, {})
+        # Assert
+        self.assertEqual(RuleResultType.SUCCESS, result.status)
+        self.assertEqual(0, len(result.issues))
+
+    def test_non_car_elasticache_redis_cluster_automatic_backup_turned_on__not_reids_engine__pass(self):
+        # Arrange
+        elasticache_cluster: ElastiCacheCluster = create_empty_entity(ElastiCacheCluster)
+        elasticache_cluster.engine = 'memcached'
+        elasticache_cluster.snapshot_retention_limit = 0
+        context = EnvironmentContext(elasticache_clusters=[elasticache_cluster])
+        # Act
+        result = self.rule.run(context, {})
+        # Assert
+        self.assertEqual(RuleResultType.SUCCESS, result.status)
+        self.assertEqual(0, len(result.issues))


### PR DESCRIPTION
modified builders and context and tests