### PR TITLE
Fix tests import error caused by knowledge refactoring

### DIFF
--- a/tests/knowledge/rules/aws/non_context_aware/log_validation_rules/test_ensure_cloudtrail_trail_exists.py
+++ b/tests/knowledge/rules/aws/non_context_aware/log_validation_rules/test_ensure_cloudtrail_trail_exists.py
@@ -1,9 +1,9 @@
 import unittest
 
-from cloudrail.knowledge.context.aws.cloudtrail.cloudtrail import CloudTrail
+from cloudrail.knowledge.context.aws.resources.cloudtrail.cloudtrail import CloudTrail
 from cloudrail.knowledge.context.aws.aws_environment_context import AwsEnvironmentContext
 from cloudrail.knowledge.rules.base_rule import RuleResultType
-from cloudrail.knowledge.context.aws.account.account import Account
+from cloudrail.knowledge.context.aws.resources.account.account import Account
 from cloudrail.knowledge.rules.aws.non_context_aware.log_validation_rules.ensure_cloudtrail_trail_exists import \
      EnsureCloudtrailTrailExists
 


### PR DESCRIPTION
#139 was fine, but then the refactoring broke the test's imports. We ran CI, it passed, then we merged. Unfortunately, in between, we had a major refactoring in the knowledge. This PR fixes the failed test.