### PR TITLE
CR-2766: [Not CAR][GCP] Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC

### DIFF
--- a/cloudrail/knowledge/rules/gcp/non_context_aware/cloud_dns_no_rsasha1_used_rules.py
+++ b/cloudrail/knowledge/rules/gcp/non_context_aware/cloud_dns_no_rsasha1_used_rules.py
@@ -1,7 +1,7 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from cloudrail.knowledge.context.gcp.gcp_environment_context import GcpEnvironmentContext
-from cloudrail.knowledge.context.gcp.resources.dns.gcp_dns_managed_zone import DnsDefKeyAlgorithm
+from cloudrail.knowledge.context.gcp.resources.dns.gcp_dns_managed_zone import GcpDnsManagedZone, DnsDefKeyAlgorithm, GcpDnsManagedZoneDnsSecCfgDefKeySpecs
 from cloudrail.knowledge.rules.base_rule import Issue
 from cloudrail.knowledge.rules.gcp.gcp_base_rule import GcpBaseRule
 from cloudrail.knowledge.rules.rule_parameters.base_paramerter import ParameterType
@@ -14,15 +14,21 @@ class CloudDnsNoRsasha1UsedRule(GcpBaseRule):
     def execute(self, env_context: GcpEnvironmentContext, parameters: Dict[ParameterType, any]) -> List[Issue]:
         issues: List[Issue] = []
         for cloud_dns in env_context.dns_managed_zones:
-            if cloud_dns.dnssec_config and \
-               cloud_dns.dnssec_config.state == 'on' and \
-               any(default_key.algorithm == DnsDefKeyAlgorithm.RSASHA1 for default_key in cloud_dns.dnssec_config.default_key_specs):
+            if affected_dns_keys := self._get_affected_keys(cloud_dns):
                 issues.append(
                     Issue(
-                        f"The {cloud_dns.get_type()} `{cloud_dns.get_friendly_name()}` has rsasha1 enabled for zone-signing and key-signing keys",
+                        f"The {cloud_dns.get_type()} `{cloud_dns.get_friendly_name()}` has rsasha1 enabled for key(s) "
+                        f"{', '.join(key.key_type.value for key in affected_dns_keys)}",
                         cloud_dns,
                         cloud_dns))
         return issues
 
     def should_run_rule(self, environment_context: GcpEnvironmentContext) -> bool:
         return bool(environment_context.dns_managed_zones)
+
+    @staticmethod
+    def _get_affected_keys(cloud_dns: GcpDnsManagedZone) -> Optional[List[GcpDnsManagedZoneDnsSecCfgDefKeySpecs]]:
+        if cloud_dns.dnssec_config and cloud_dns.dnssec_config.state == 'on':
+            return [default_key for default_key in cloud_dns.dnssec_config.default_key_specs
+                    if default_key.algorithm == DnsDefKeyAlgorithm.RSASHA1]
+        return None

--- a/tests/knowledge/rules/gcp/non_context_aware/test_cloud_dns_no_rsasha1_used_rules.py
+++ b/tests/knowledge/rules/gcp/non_context_aware/test_cloud_dns_no_rsasha1_used_rules.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from parameterized import parameterized
 from cloudrail.dev_tools.rule_test_utils import create_empty_entity
 from cloudrail.knowledge.context.gcp.gcp_environment_context import GcpEnvironmentContext
-from cloudrail.knowledge.context.gcp.resources.dns.gcp_dns_managed_zone import GcpDnsManagedZone, GcpDnsManagedZoneDnsSecCfg, GcpDnsManagedZoneDnsSecCfgDefKeySpecs, DnsDefKeyAlgorithm
+from cloudrail.knowledge.context.gcp.resources.dns.gcp_dns_managed_zone import GcpDnsManagedZone, GcpDnsManagedZoneDnsSecCfg, GcpDnsManagedZoneDnsSecCfgDefKeySpecs, DnsDefKeyAlgorithm, DnsDefKeyType
 from cloudrail.knowledge.rules.base_rule import RuleResultType
 from cloudrail.knowledge.rules.gcp.non_context_aware.cloud_dns_no_rsasha1_used_rules import CloudDnsNoRsasha1UsedRule
 
@@ -22,9 +22,13 @@ class TestCloudDnsNoRsasha1UsedRule(TestCase):
         # Arrange
         dns_managed_zone = create_empty_entity(GcpDnsManagedZone)
         dns_config = create_empty_entity(GcpDnsManagedZoneDnsSecCfg)
-        default_key_conf = create_empty_entity(GcpDnsManagedZoneDnsSecCfgDefKeySpecs)
-        default_key_conf.algorithm = DnsDefKeyAlgorithm(rsa_version)
-        dns_config.default_key_specs = [default_key_conf]
+        default_key_conf_a = create_empty_entity(GcpDnsManagedZoneDnsSecCfgDefKeySpecs)
+        default_key_conf_a.algorithm = DnsDefKeyAlgorithm(rsa_version)
+        default_key_conf_a.key_type = DnsDefKeyType.KEYSIGNING
+        default_key_conf_b = create_empty_entity(GcpDnsManagedZoneDnsSecCfgDefKeySpecs)
+        default_key_conf_b.algorithm = DnsDefKeyAlgorithm(rsa_version)
+        default_key_conf_b.key_type = DnsDefKeyType.ZONESIGNING
+        dns_config.default_key_specs = [default_key_conf_a, default_key_conf_b]
         dns_config.state = 'on'
         dns_managed_zone.dnssec_config = dns_config
         context = GcpEnvironmentContext(dns_managed_zones=[dns_managed_zone])


### PR DESCRIPTION
modified rule syntax